### PR TITLE
Update GitHubCopilotDemo.md

### DIFF
--- a/GitHubCopilotDemo.md
+++ b/GitHubCopilotDemo.md
@@ -23,7 +23,7 @@ This training is for developers who want to use Copilot specifically within Inte
    To use GitHub Copilot, you need an active subscription. There are two main types of subscriptions:
 
    - **Individual Subscription**: This is for individual developers who want to use Copilot for personal projects. It provides access to all Copilot features within supported IDEs.
-   - **Organizational Subscription**: This is for teams and organizations. It allows multiple users within an organization to use Copilot, providing centralized billing and management. This option is ideal for companies looking to enhance their development workflow across the team.
+   - **Organizational Subscription (Business or Enterprise)**: This is for teams and organizations. It allows multiple users within an organization to use Copilot, providing centralized billing and management. This option is ideal for companies looking to enhance their development workflow across the team.
 
 2. **Compatible IntelliJ IDEA Version**  
    GitHub Copilot is compatible with the following IntelliJ IDEA versions:


### PR DESCRIPTION
This pull request includes a small change to the `GitHubCopilotDemo.md` file. The change clarifies the types of organizational subscriptions available for GitHub Copilot by specifying that they are for "Business or Enterprise" users.

* [`GitHubCopilotDemo.md`](diffhunk://#diff-362e1874c28dff7cd16661d079ad7ab8a5f1df48133dbbbcd74735f9b0be4a41L26-R26): Updated the description of the organizational subscription to specify "Business or Enterprise" users.